### PR TITLE
feat(w2c): X-w2c-call-me header (w2cC2CId) + Call.toJson sur v1.1.0

### DIFF
--- a/lib/src/rtc_session.dart
+++ b/lib/src/rtc_session.dart
@@ -128,6 +128,7 @@ class RTCSession extends EventManager implements Owner {
 
   // Session info.
   Direction? _direction;
+  String? _w2cC2CId;
   NameAddrHeader? _local_identity;
   NameAddrHeader? _remote_identity;
   DateTime? _start_time;
@@ -180,6 +181,8 @@ class RTCSession extends EventManager implements Owner {
   String? get contact => _contact;
 
   Direction? get direction => _direction;
+
+  String? get w2cC2CId => _w2cC2CId;
 
   NameAddrHeader? get local_identity => _local_identity;
 
@@ -365,6 +368,7 @@ class RTCSession extends EventManager implements Owner {
       [Function(RTCSession)? initCallback]) {
     logger.d('init_incoming()');
 
+    _w2cC2CId = request.getHeader('X-w2c-call-me');
     int? expires;
     String? contentType = request.getHeader('Content-Type');
 

--- a/lib/src/sip_ua_helper.dart
+++ b/lib/src/sip_ua_helper.dart
@@ -712,6 +712,33 @@ class Call {
     return peerHasMediaLine;
   }
 
+  Map<String, dynamic> toJson() {
+    var isMuted = _session.isMuted();
+    var isOnHold = _session.isOnHold();
+    return {
+      'id': id,
+      'sessionId': _session.id,
+      'sessionStatus': _session.status,
+      'sessionContact': _session.contact,
+      'sessionDirection': _session.direction?.name,
+      'sessionW2cC2CId': _session.w2cC2CId ?? '',
+      'sessionLocalIdentity': local_identity,
+      'sessionRemoteIdentity': remote_identity,
+      'sessionRemoteDisplayName': remote_display_name,
+      'sessionRemoteHasAudio': remote_has_audio,
+      'sessionRemoteHasVideo': remote_has_video,
+      'sessionStartTime': _session.start_time.toString(),
+      'sessionEndTime': _session.end_time.toString(),
+      'sessionIsInProgress': _session.isInProgress(),
+      'sessionIsEstablished': _session.isEstablished(),
+      'sessionIsEnded': _session.isEnded(),
+      'sessionIsAudioMuted': isMuted['audio'],
+      'sessionIsVideoMuted': isMuted['video'],
+      'sessionIsLocalOnHold': isOnHold['local'],
+      'sessionIsRemoteOnHold': isOnHold['remote'],
+    };
+  }
+
   Future<List<StatsReport>>? getStats([MediaStreamTrack? track]) {
     return peerConnection?.getStats(track);
   }


### PR DESCRIPTION
## Objet
Re-port de notre personnalisation W2C (anciennement PR #2, basée sur l'ancien master 0.5.3) sur le nouveau master v1.1.0.

## Ce que ça ajoute
- `lib/src/rtc_session.dart` : champ `_w2cC2CId` + getter `w2cC2CId`, alimenté dans `init_incoming()` depuis l'en-tête SIP **`X-w2c-call-me`** (porté sur l'INVITE entrant). Expose `call.session.w2cC2CId`, utilisé côté app pour rattacher l'appel au click-to-call.
- `lib/src/sip_ua_helper.dart` : méthode `Call.toJson()` (incluant `sessionW2cC2CId`), requise car l'app fait `jsonEncode(call)` pour sa télémétrie.

## Adaptation v1.1.0
- `direction` est désormais un enum (`Direction?`) → `toJson` utilise `direction?.name`.
- Changement purement additif, aucune régression sur l'API publique.

## Notes
- Le nom d'en-tête `X-w2c-call-me` et le nom de propriété `w2cC2CId` sont conservés à l'identique (compat FreeSWITCH + app).
- `w2cCallMe` n'est volontairement pas réintroduit (inutilisé dans l'app).
- Sert de base (tag `1.1.0-w2c.1`) à la modernisation de l'app web2contact (passage à flutter_webrtc 1.x, qui corrige le crash d'appel sur Android 13).
