### PR TITLE
fix(websocket): détecter la mort de la socket pour armer la reconnexion

### DIFF
--- a/lib/src/sip_ua_helper.dart
+++ b/lib/src/sip_ua_helper.dart
@@ -841,6 +841,15 @@ class WebSocketSettings {
   /// Otherwise the used protocol will be used (for example WS for ws://
   /// or WSS for wss://, based on the given web socket URL).
   String? transport_scheme;
+
+  /// Interval between the WebSocket ping frames used to detect a half open
+  /// socket (TCP dead on the network but never closed on the client side,
+  /// typically an idle connection dropped by a proxy or a sleeping handset).
+  /// `dart:io` closes the connection when no pong comes back, which arms the
+  /// transport reconnection. Set to `null` to disable the keep alive.
+  ///
+  /// Ignored on web, where the browser handles the keep alive itself.
+  Duration? pingInterval = const Duration(seconds: 30);
 }
 
 class TcpSocketSettings {

--- a/lib/src/transports/websocket_dart_impl.dart
+++ b/lib/src/transports/websocket_dart_impl.dart
@@ -10,6 +10,10 @@ typedef OnMessageCallback = void Function(dynamic msg);
 typedef OnCloseCallback = void Function(int? code, String? reason);
 typedef OnOpenCallback = void Function();
 
+/// Close code reported when the socket dies without a close handshake,
+/// i.e. RFC 6455 `1006 abnormal closure`.
+const int abnormalClosure = 1006;
+
 class SIPUAWebSocketImpl {
   SIPUAWebSocketImpl(this._url, this.messageDelay);
 
@@ -19,6 +23,13 @@ class SIPUAWebSocketImpl {
   OnMessageCallback? onMessage;
   OnCloseCallback? onClose;
   final int messageDelay;
+
+  /// Set once the death of the socket has been reported upstream, or once the
+  /// caller closed it on purpose. A socket dying on error usually emits both
+  /// an error and a done event, and each report would arm its own
+  /// reconnection.
+  bool _closeHandled = false;
+
   void connect(
       {Iterable<String>? protocols,
       required WebSocketSettings webSocketSettings}) async {
@@ -33,40 +44,90 @@ class SIPUAWebSocketImpl {
             protocols: protocols, headers: webSocketSettings.extraHeaders);
       }
 
-      onOpen?.call();
+      // Keep alive: `dart:io` emits the ping frames and closes the connection
+      // when no pong comes back, which is the only way to notice a half open
+      // socket (TCP dead on the network but never closed on our side).
+      _socket!.pingInterval = webSocketSettings.pingInterval;
+
+      // Listen before signalling the open state: a message arriving in
+      // between would be lost.
       _socket!.listen((dynamic data) {
         onMessage?.call(data);
+      }, onError: (Object error, StackTrace stackTrace) {
+        logger.e('WebSocket $_url error: $error',
+            error: error, stackTrace: stackTrace);
+        _handleClose(_socket?.closeCode ?? abnormalClosure,
+            _socket?.closeReason ?? error.toString());
       }, onDone: () {
-        onClose?.call(_socket!.closeCode, _socket!.closeReason);
+        _handleClose(_socket?.closeCode, _socket?.closeReason);
       });
+
+      onOpen?.call();
     } catch (e) {
-      onClose?.call(500, e.toString());
+      _handleClose(500, e.toString());
     }
   }
 
   final StreamController<dynamic> queue = StreamController<dynamic>.broadcast();
+  StreamSubscription<dynamic>? _queueSubscription;
   void handleQueue() async {
-    queue.stream.asyncMap((dynamic event) async {
+    _queueSubscription = queue.stream.asyncMap((dynamic event) async {
       await Future<void>.delayed(Duration(milliseconds: messageDelay));
       return event;
-    }).listen((dynamic event) async {
-      _socket!.add(event);
-      logger.d('send: \n\n$event');
+    }).listen((dynamic event) {
+      // This is where the write really happens, `send()` only enqueues. A
+      // failure here must surface as a disconnection, otherwise the message
+      // vanishes while the transport keeps believing it is connected.
+      try {
+        _socket!.add(event);
+        logger.d('send: \n\n$event');
+      } catch (error, stackTrace) {
+        logger.e('WebSocket $_url send failure: $error',
+            error: error, stackTrace: stackTrace);
+        _handleClose(
+            _socket?.closeCode ?? abnormalClosure, 'send failure: $error');
+      }
+    }, onError: (Object error, StackTrace stackTrace) {
+      logger.e('WebSocket $_url send queue failure: $error',
+          error: error, stackTrace: stackTrace);
+      _handleClose(
+          _socket?.closeCode ?? abnormalClosure, 'send queue failure: $error');
     });
   }
 
   void send(dynamic data) async {
-    if (_socket != null) {
-      queue.add(data);
+    if (_socket == null || queue.isClosed) {
+      logger.e('WebSocket $_url not connected, message not sent');
+      return;
     }
+    queue.add(data);
   }
 
   void close() {
+    // Closing on purpose: the caller already knows, nothing to report back.
+    _closeHandled = true;
+    _closeQueue();
     if (_socket != null) _socket!.close();
   }
 
   bool isConnecting() {
     return _socket != null && _socket!.readyState == WebSocket.connecting;
+  }
+
+  /// Reports the death of the socket upstream, at most once.
+  void _handleClose(int? code, String? reason) {
+    if (_closeHandled) return;
+    _closeHandled = true;
+    _closeQueue();
+    onClose?.call(code, reason);
+  }
+
+  /// Releases the send queue: the socket is gone, nothing can be written any
+  /// more, and a brand new instance is built on every reconnection.
+  void _closeQueue() {
+    _queueSubscription?.cancel();
+    _queueSubscription = null;
+    if (!queue.isClosed) queue.close();
   }
 
   /// For test only.

--- a/test/test_websocket_recovery.dart
+++ b/test/test_websocket_recovery.dart
@@ -1,0 +1,169 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import 'package:sip_ua/src/sip_ua_helper.dart';
+import 'package:sip_ua/src/transports/socket_interface.dart';
+import 'package:sip_ua/src/transports/web_socket.dart';
+
+/// Regression tests for the recovery path of [SIPUAWebSocket]: a socket that
+/// dies must always be reported through `ondisconnect`, otherwise the
+/// transport keeps believing it is connected and never reconnects.
+///
+/// Both scenarios go through a raw TCP proxy sitting between the client and a
+/// local WebSocket server, the only way to reproduce a connection dying
+/// without a close handshake and a half open connection.
+///
+/// The first one is a non regression guard, it already held before the ping
+/// keep alive. The second one only passes with it: without a ping, nothing is
+/// ever emitted and the socket stays believed connected forever.
+List<void Function()> testFunctions = <void Function()>[
+  () => test(' WebSocket: abrupt disconnection is reported', () async {
+        _EchoServer server = await _EchoServer.start();
+        _TcpProxy proxy = await _TcpProxy.start(server.port);
+        Completer<String?> disconnected = Completer<String?>();
+
+        SIPUAWebSocket client =
+            SIPUAWebSocket('ws://127.0.0.1:${proxy.port}/sip', messageDelay: 0);
+
+        client.onconnect = () {
+          // The connection dies without a close frame: cable unplugged, RST
+          // from a proxy, Wi-Fi to mobile handover.
+          proxy.killConnections();
+          // Exercise the write path on the dead socket: it must not throw out
+          // of the queue listener nor keep the transport hanging.
+          client.send('OPTIONS sip:127.0.0.1 SIP/2.0\r\n\r\n');
+        };
+        client.ondata = (dynamic data) {};
+        client.ondisconnect = (SIPUASocketInterface socket, bool error,
+            int? closeCode, String? reason) {
+          if (!disconnected.isCompleted) disconnected.complete(reason);
+        };
+        client.connect();
+
+        String? reason = await disconnected.future.timeout(
+            const Duration(seconds: 10),
+            onTimeout: () =>
+                throw StateError('the death of the socket was never reported'));
+        print('disconnected => $reason');
+        expect(client.isConnected(), false);
+
+        client.disconnect();
+        await proxy.stop();
+        await server.stop();
+      }),
+  () => test(' WebSocket: half open socket is detected by the ping', () async {
+        _EchoServer server = await _EchoServer.start();
+        _TcpProxy proxy = await _TcpProxy.start(server.port);
+        Completer<String?> disconnected = Completer<String?>();
+
+        WebSocketSettings settings = WebSocketSettings();
+        settings.pingInterval = const Duration(seconds: 2);
+
+        SIPUAWebSocket client = SIPUAWebSocket(
+            'ws://127.0.0.1:${proxy.port}/sip',
+            messageDelay: 0,
+            webSocketSettings: settings);
+
+        client.onconnect = () {
+          // Nothing travels any more, but the socket stays open on both
+          // sides: without the ping nobody can ever notice.
+          proxy.blackHole = true;
+        };
+        client.ondata = (dynamic data) {};
+        client.ondisconnect = (SIPUASocketInterface socket, bool error,
+            int? closeCode, String? reason) {
+          if (!disconnected.isCompleted) disconnected.complete(reason);
+        };
+        client.connect();
+
+        String? reason = await disconnected.future.timeout(
+            const Duration(seconds: 15),
+            onTimeout: () =>
+                throw StateError('the half open socket was never detected'));
+        print('disconnected => $reason');
+        expect(client.isConnected(), false);
+
+        client.disconnect();
+        await proxy.stop();
+        await server.stop();
+      }),
+];
+
+/// Minimal WebSocket server echoing back whatever it receives.
+class _EchoServer {
+  _EchoServer(this._server);
+
+  static Future<_EchoServer> start() async {
+    HttpServer server = await HttpServer.bind('127.0.0.1', 0);
+    server.listen((HttpRequest req) async {
+      if (req.uri.path != '/sip') {
+        req.response.statusCode = HttpStatus.notFound;
+        await req.response.close();
+        return;
+      }
+      WebSocket socket = await WebSocketTransformer.upgrade(req);
+      socket.listen((dynamic msg) => socket.add(msg), onError: (dynamic e) {});
+    });
+    return _EchoServer(server);
+  }
+
+  final HttpServer _server;
+
+  int get port => _server.port;
+
+  Future<void> stop() => _server.close(force: true);
+}
+
+/// Raw TCP proxy able to kill the connections it relays, or to stop relaying
+/// while keeping them open.
+class _TcpProxy {
+  _TcpProxy(this._server, this._targetPort);
+
+  static Future<_TcpProxy> start(int targetPort) async {
+    ServerSocket server = await ServerSocket.bind('127.0.0.1', 0);
+    _TcpProxy proxy = _TcpProxy(server, targetPort);
+    server.listen(proxy._relay);
+    return proxy;
+  }
+
+  final ServerSocket _server;
+  final int _targetPort;
+  final List<Socket> _sockets = <Socket>[];
+
+  /// Stops relaying in both directions without closing anything: the
+  /// connection looks alive to both ends while nothing goes through.
+  bool blackHole = false;
+
+  int get port => _server.port;
+
+  Future<void> _relay(Socket downstream) async {
+    Socket upstream = await Socket.connect('127.0.0.1', _targetPort);
+    _sockets.addAll(<Socket>[downstream, upstream]);
+    downstream.listen((List<int> data) {
+      if (!blackHole) upstream.add(data);
+    }, onError: (dynamic e) {}, onDone: () => upstream.destroy());
+    upstream.listen((List<int> data) {
+      if (!blackHole) downstream.add(data);
+    }, onError: (dynamic e) {}, onDone: () => downstream.destroy());
+  }
+
+  void killConnections() {
+    for (Socket socket in _sockets) {
+      socket.destroy();
+    }
+    _sockets.clear();
+  }
+
+  Future<void> stop() async {
+    killConnections();
+    await _server.close();
+  }
+}
+
+void main() {
+  for (Function func in testFunctions) {
+    func();
+  }
+}


### PR DESCRIPTION
Closes #4

Une socket qui mourait autrement que par une fermeture propre laissait
`SocketTransport.status` à `connected` définitivement : `isConnected()` vrai,
messages SIP écrits dans le vide, boucle de reconnexion jamais armée. Les
quatre points du correctif demandé sont appliqués, plus le point annexe.
Le patch w2c (`w2cC2CId`) n'est pas touché.

## Changements

`lib/src/transports/websocket_dart_impl.dart`

- `onError` sur le listen de la socket, routé vers `onClose` avec un code
  exploitable (`1006` à défaut de code de fermeture)
- `onError` sur le listener de `handleQueue`, et `_socket.add()` enveloppé :
  un échec d'écriture devient une déconnexion au lieu d'un silence
- `pingInterval` posé sur la socket, sur les deux chemins de connexion
  (`WebSocket.connect` et `_connectForBadCertificate`)
- `onOpen?.call()` déplacé **après** l'installation du listener : un message
  arrivé entre les deux n'est plus perdu
- `close()` ferme le `StreamController queue` et annule son abonnement
- garde `_closeHandled` : la mort d'une socket n'est reportée qu'une fois.
  Sans elle, error + done armaient deux reconnexions concurrentes, et la
  socket d'une instance abandonnée pouvait faire tomber la nouvelle
  (`SIPUAWebSocket.connect()` instancie un impl neuf à chaque reconnexion,
  les callbacks de l'ancien pointant toujours sur le même wrapper)

`lib/src/sip_ua_helper.dart`

- `WebSocketSettings.pingInterval`, `Duration(seconds: 30)` par défaut,
  `null` pour désactiver le keep-alive. Ignoré sur web, le navigateur s'en
  charge.

`test/test_websocket_recovery.dart` (nouveau)

Deux tests de non-régression, un proxy TCP intercalé entre le client et un
serveur WebSocket local pour reproduire une mort sans handshake et une
socket half-open. Fichier autonome avec son `main()`, comme
`test_websocket.dart`, non branché sur `all_test.dart`.

## Vérification

Dart 3.6 / Flutter 3.27 en conteneur.

- `dart analyze lib/` : 3 infos préexistantes (`var` dans `sip_ua_helper`),
  aucune nouvelle
- `dart format --set-exit-if-changed lib/ test/` : propre
- `import_sorter --exit-if-changed` : seule plainte, préexistante, dans
  `websocket_web_impl.dart` (fichier non modifié)
- **32/32 tests passent** : `all_test` (28), `test_websocket` (2, echo
  nominal inchangé), `test_websocket_recovery` (2)

Mesures faites sur `dart:io` avec une sonde isolée, qui nuancent le
diagnostic de l'issue :

| scénario | résultat |
|---|---|
| destruction brutale de la connexion | `onDone`, code `1005` — pas d'événement `error`, ce cas remontait **déjà** |
| half-open, sans ping | **rien après 20 s** — indétectable, c'est la cause du symptôme en production |
| half-open, ping 2 s | `onDone` code `1001` à **4 s**, soit ≈ 2× l'intervalle |
| `add()` sur socket morte | **ne lève pas**, l'écriture est bufferisée puis ignorée |

Autrement dit : c'est le `pingInterval` qui règle le problème de production.
`onError` et la remontée d'échec d'écriture sont des filets défensifs, gratuits
mais qui ne se déclenchent quasiment jamais sur `dart:io`. Avec 30 s par
défaut, une socket half-open est vue en ~60 s.

## Reste à valider sur device

Le risque signalé dans l'issue : si le pair (nginx, mod_sofia) ne rend pas les
pings, la connexion sera fermée à chaque intervalle. Le RFC 6455 impose le
pong et mod_sofia l'implémente, mais ça se constate. Repli sans changer
d'approche : `settings.webSocketSettings.pingInterval = null`.

À vérifier en recette : appel en cours non interrompu, et absence de
déconnexion périodique parasite.

## Après merge

Poser le tag `1.1.0-w2c.2` (le consommateur épingle `1.1.0-w2c.1`).